### PR TITLE
Add CSS for sticky header in HTML report

### DIFF
--- a/ADRecon.ps1
+++ b/ADRecon.ps1
@@ -4318,6 +4318,8 @@ $Header = @"
 th {
 	color:white;
 	background-color:blue;
+	position: sticky;
+	top: 0px;
 }
 td, th {
 	border:0px solid black;


### PR DESCRIPTION
The HTML Report is much more usable with sticky table headers, since the tables can get quite big and it's easy to lose track of the columns.